### PR TITLE
Use inclusive filter for start and end dates

### DIFF
--- a/frontend/src/components/organism/Projections.tsx
+++ b/frontend/src/components/organism/Projections.tsx
@@ -28,8 +28,10 @@ const Projections: React.FC<{ className?: string }> = ({ className }) => {
     transactions
       .filter(t =>
         moment(t.date).isBetween(
-          moment().startOf('month'),
-          moment().add(5, 'years')
+          moment(),
+          moment().add(5, 'years'),
+          'month',
+          '[]'
         )
       )
       .sort((t1, t2) => (t2.date > t1.date ? -1 : 1))


### PR DESCRIPTION
This PR ensures that 
* The *first* transaction each month is guaranteed to be included.
* The *last* transaction each month is guaranteed to be included.

In the first case, the problem is that `isBetween` is exclusive.
In the second case, there was not an "update" to the last day of the month.