### PR TITLE
Add a disrupting tag to Form to prevent memory leak

### DIFF
--- a/frontend/src/components/organism/authentication/Login.tsx
+++ b/frontend/src/components/organism/authentication/Login.tsx
@@ -21,6 +21,7 @@ const Login: React.FC<
       <h1 data-testid="authform-header">Sign in</h1>
 
       <Form
+        disrupting={true}
         schema={[
           {
             id: 'login-email',

--- a/frontend/src/components/organism/authentication/Register.tsx
+++ b/frontend/src/components/organism/authentication/Register.tsx
@@ -27,6 +27,7 @@ const Register: React.FC<
       <h1 data-testid="authform-header">Sign up</h1>
 
       <Form
+        disrupting={true}
         schema={[
           {
             id: 'register-first_name',


### PR DESCRIPTION
This exists because of forms like register and login, which may redirect the user.
Without this, we will run into a memory leak where it will try to perform actions
on an unmounted component.