### PR TITLE
Wrap isOwner retrieval in a try/catch as it might crash when !company

### DIFF
--- a/frontend/src/components/molecules/Company.tsx
+++ b/frontend/src/components/molecules/Company.tsx
@@ -33,8 +33,12 @@ const Company: React.FC<ICompanyProps> = ({ className, company }) => {
     );
   };
 
-  const isOwner =
-    company.users.find(u => u.user_id === auth!.id)!.role === 'OW';
+  let isOwner: boolean;
+  try {
+    isOwner = company.users.find(u => u.user_id === auth!.id)!.role === 'OW';
+  } catch (e) {
+    isOwner = false;
+  }
 
   const onClickDelete: React.MouseEventHandler = async () => {
     await AuthActions.doRemoveCompanyFromUser(company.id, authDispatch);


### PR DESCRIPTION
As described by the title; when deleting a company, it would sometimes crash as the user was no longer actually in the company, but the frontend thought so, and thus crashed by asserting this.