### PR TITLE
Add linebreak to the contents of projection row to make sure they maintain their structure when having long descriptions

### DIFF
--- a/frontend/src/components/atoms/ProjectionRow.tsx
+++ b/frontend/src/components/atoms/ProjectionRow.tsx
@@ -20,6 +20,7 @@ const ProjectionRow = styled.div`
     align-self: center;
     margin-top: 0.2em;
     margin-bottom: 0.2em;
+    word-break: break-word;
   }
 
   p:nth-last-child(-n + 3),


### PR DESCRIPTION
Closes #214 